### PR TITLE
Allow processing route tatgets as object

### DIFF
--- a/src/route-processor.test.ts
+++ b/src/route-processor.test.ts
@@ -9,15 +9,12 @@ function getMockComponent() {
   });
 }
 
-test('test route processing', () => {
+function getMockRoutes() {
   // Setup routes
   const routes = {
     home: new RouteTarget(),
     about: new RouteTarget(),
   };
-
-  // Make sure route IDs are unique
-  expect(routes.home.id).not.toBe(routes.about.id);
 
   // Setup routing tree
   const routingTree: RouteRecordRaw[] = [
@@ -45,8 +42,26 @@ test('test route processing', () => {
     }
   ];
 
+  return {routes, routingTree};
+}
+
+test('test route processing using routes as a list', () => {
+  const {routes, routingTree} = getMockRoutes();
+  const routesList = [routes.home, routes.about];
+  
   // Process routes
-  processRoutes(routingTree, Object.values(routes));
+  processRoutes(routingTree, routesList);
+
+  // Check paths
+  expect(routes.home.path).toBe('/');
+  expect(routes.about.path).toBe('/about/hello');
+});
+
+test('test route processing using routes as an object', () => {
+  const {routes, routingTree} = getMockRoutes();
+
+  // Process routes
+  processRoutes(routingTree, routes);
 
   // Check paths
   expect(routes.home.path).toBe('/');

--- a/src/route-processor.ts
+++ b/src/route-processor.ts
@@ -11,8 +11,17 @@ function concatRoutePath (path: string | null, extension: string): string {
   return path + '/' + extension;
 }
 
-export function processRoutes (routesTree: RouteRecordRaw[], routeTargets: RouteTarget[], prefix: string | null = null) {
+export function processRoutes (
+  routesTree: RouteRecordRaw[],
+  routeTargets: RouteTarget[] | {[key: string]: RouteTarget},
+  prefix: string | null = null
+) {
   for (const route of routesTree) {
+    // Extract route targets if passed as an object
+    if (!(routeTargets instanceof Array)) {
+      routeTargets = Object.values(routeTargets);
+    }
+
     // Update route path and route target path
     const matchingTarget = routeTargets.find(target => target.id === route.path);
     if (matchingTarget) {

--- a/src/route-target.test.ts
+++ b/src/route-target.test.ts
@@ -1,0 +1,15 @@
+import {expect, test} from 'vitest';
+import {RouteTarget} from './route-target.ts';
+
+test('test route target IDs', () => {
+// Setup routes
+  const routes = {
+    home: new RouteTarget(),
+    about: new RouteTarget(),
+  };
+
+  // Make sure route IDs are unique and not null
+  expect(routes.home.id).not.toBeNull();
+  expect(routes.about.id).not.toBeNull();
+  expect(routes.home.id).not.toBe(routes.about.id);
+});


### PR DESCRIPTION
Allow `routeTargets` in `processRoutes` to be an object containing route target instances. This is to simplify usage of the library.

Now you can do this:

```ts
const routes = {
  home: new RouteTarget(),
  about: new RouteTarget(),
};

const routingTree: RouteRecordRaw[] = ...;

// Process routes without any further transformations
processRoutes(routingTree, routes);
```